### PR TITLE
Sync flow json with default config and fix is-init bug 

### DIFF
--- a/flow.json
+++ b/flow.json
@@ -14,7 +14,7 @@
   "accounts": {
     "emulator-account": {
       "address": "f8d6e0586b0a20c7",
-      "keys": "033bb22e1b6d5779623107241f80e9d1bf3c9bc569db72d098849b0b6a1db646"
+      "keys": "84f82df6790f07b281adb5bbc848bd6298a2de67f94bdfac7a400d5a1b893de5"
     }
   },
   "deployments": {}

--- a/pages/api/is-init.js
+++ b/pages/api/is-init.js
@@ -18,7 +18,7 @@ export default async (req, res) => {
         res.status(200).json(true)
     }
     else{
-        res.status(200).json(true)
+        res.status(200).json(false)
     }
   } catch (error) {
     res.status(200).json(false)


### PR DESCRIPTION
- Avoid unnecessary FCL import errors
- Sync flow.json private key with .env.sample
- bug fix for is-init
