### PR TITLE
Save app title and icon for authz  dialog

### DIFF
--- a/components/AccountsListItem.tsx
+++ b/components/AccountsListItem.tsx
@@ -78,11 +78,10 @@ export default function AccountsListItem({
   onEditAccount: (account: Account | NewAccount) => void
   isNew: boolean
 }) {
+  const {connectedAppConfig} = useAuthnContext()
   const {
-    connectedAppConfig: {
-      app: {title},
-    },
-  } = useAuthnContext()
+    app: {title},
+  } = connectedAppConfig
 
   const [showScopes, setShowScopes] = useState(false)
   const [scopes, setScopes] = useState<Set<string>>(new Set(account.scopes))
@@ -104,7 +103,7 @@ export default function AccountsListItem({
           <Button
             variant="unstyled"
             sx={styles.chooseAccountButton}
-            onClick={e => chooseAccount(account, scopes)(e)}
+            onClick={e => chooseAccount(account, scopes, connectedAppConfig)(e)}
             data-test="log-in-button"
           >
             <AccountImage

--- a/components/AuthzDetailsTable.tsx
+++ b/components/AuthzDetailsTable.tsx
@@ -50,8 +50,8 @@ const styles: SXStyles = {
     mr: 2,
   },
   accountDetailLabelCurrent: {
-    backgroundColor: "green",
-    borderColor: "green",
+    backgroundColor: "primary",
+    borderColor: "primary",
     color: "black",
     fontWeight: 700,
   },

--- a/components/AuthzHeader.tsx
+++ b/components/AuthzHeader.tsx
@@ -1,5 +1,6 @@
 /** @jsxImportSource theme-ui */
 import useAuthzContext from "hooks/useAuthzContext"
+import {UNTITLED_APP_NAME} from "src/constants"
 import {Label} from "theme-ui"
 import {SXStyles} from "types"
 import AccountImage from "./AccountImage"
@@ -30,7 +31,7 @@ const styles: SXStyles = {
     position: "absolute",
     mt: "-2px",
     left: -15,
-    backgroundColor: "green",
+    backgroundColor: "primary",
     width: 7,
     height: 7,
     borderRadius: 7,
@@ -42,22 +43,24 @@ const styles: SXStyles = {
 }
 
 function AuthzHeader() {
-  const {currentUser, appTitle, appIcon} = useAuthzContext()
+  const {currentUser, connectedAppConfig} = useAuthzContext()
+  const title = connectedAppConfig?.app?.title || UNTITLED_APP_NAME
+  const icon = connectedAppConfig?.app?.icon
   return (
     <div sx={styles.header}>
       <div sx={styles.transactionIcon}>
         <img src="/transaction.svg" />
       </div>
       <div sx={styles.headerSection}>
-        <AccountImage address={currentUser.address} seed={appTitle} lg={true} />
+        <AccountImage address={currentUser.address} seed={title} lg={true} />
         <Label sx={styles.label}>
           <div sx={styles.greenDot} />
           {currentUser.label}
         </Label>
       </div>
       <div sx={styles.headerSection}>
-        <AccountImage src={appIcon} seed={appTitle} lg={true} />
-        <Label sx={styles.label}>{appTitle}</Label>
+        <AccountImage src={icon} seed={title} lg={true} />
+        <Label sx={styles.label}>{title}</Label>
       </div>
     </div>
   )

--- a/components/Code.tsx
+++ b/components/Code.tsx
@@ -12,7 +12,7 @@ const styles: SXStyles = {
   },
   block: {
     backgroundColor: "gray.100",
-    maxHeight: 184,
+    maxHeight: 120,
     overflow: "auto",
     py: 15,
     px: 30,

--- a/components/ConnectedAppHeader.tsx
+++ b/components/ConnectedAppHeader.tsx
@@ -4,6 +4,7 @@ import InfoIcon from "components/InfoIcon"
 import useAuthnContext from "hooks/useAuthnContext"
 import {Account, NewAccount} from "pages/api/accounts"
 import {useState} from "react"
+import {UNTITLED_APP_NAME} from "src/constants"
 import {Button, Themed} from "theme-ui"
 import {SXStyles} from "types"
 
@@ -81,7 +82,7 @@ export default function ConnectedAppHeader({
               </div>
               <div>
                 <span sx={styles.infoLabel}>app.detail.title:</span>{" "}
-                {connectedAppTitle}
+                {connectedAppTitle || UNTITLED_APP_NAME}
               </div>
               <Themed.hr />
             </div>

--- a/contexts/AuthzContext.tsx
+++ b/contexts/AuthzContext.tsx
@@ -1,5 +1,6 @@
 import * as fcl from "@onflow/fcl"
 import useAccounts from "hooks/useAccounts"
+import {ConnectedAppConfig} from "hooks/useConnectedAppConfig"
 import {Account} from "pages/api/accounts"
 import React, {createContext, useEffect, useMemo, useState} from "react"
 import reply from "src/reply"
@@ -63,8 +64,7 @@ type AuthzContextType = {
   codePreview: CodePreview | null
   setCodePreview: React.Dispatch<React.SetStateAction<CodePreview | null>>
   isExpanded: boolean
-  appTitle: string
-  appIcon: string
+  connectedAppConfig: ConnectedAppConfig | undefined
 }
 
 export const AuthzContext = createContext<AuthzContextType>({
@@ -87,8 +87,7 @@ export const AuthzContext = createContext<AuthzContextType>({
   codePreview: null,
   setCodePreview: () => null,
   isExpanded: false,
-  appTitle: "",
-  appIcon: "",
+  connectedAppConfig: undefined,
 })
 
 export function AuthzContextProvider({children}: {children: React.ReactNode}) {
@@ -126,7 +125,7 @@ export function AuthzContextProvider({children}: {children: React.ReactNode}) {
   if (!signable || !id || Object.entries(accounts).length === 0) return null
 
   const {addr: currentUserAddress, voucher, roles, message} = signable
-
+  const savedConnectedAppConfig = localStorage.getItem("connectedAppConfig")
   const value = {
     currentUser: accounts[fcl.withPrefix(currentUserAddress)],
     proposer: accounts[fcl.withPrefix(voucher.proposalKey.address)],
@@ -145,6 +144,9 @@ export function AuthzContextProvider({children}: {children: React.ReactNode}) {
     codePreview,
     setCodePreview,
     isExpanded: codePreview !== null,
+    connectedAppConfig: savedConnectedAppConfig
+      ? JSON.parse(savedConnectedAppConfig)
+      : undefined,
     appTitle: "Test Harness",
     appIcon: "https://placekitten.com/g/200/200",
   }

--- a/src/accountAuth.ts
+++ b/src/accountAuth.ts
@@ -1,3 +1,4 @@
+import {ConnectedAppConfig} from "hooks/useConnectedAppConfig"
 import {Account} from "pages/api/accounts"
 
 const PROFILE_SCOPES = new Set(
@@ -65,7 +66,11 @@ function authnResponse(data: AuthResponseData) {
   }
 }
 
-export function chooseAccount(account: Account, scopes: Set<string>) {
+export function chooseAccount(
+  account: Account,
+  scopes: Set<string>,
+  connectedAppConfig: ConnectedAppConfig
+) {
   const {address, keyId} = account
   const services: AuthResponseService[] = [
     {
@@ -163,6 +168,8 @@ export function chooseAccount(account: Account, scopes: Set<string>) {
       },
     })
   }
+
+  localStorage.setItem("connectedAppConfig", JSON.stringify(connectedAppConfig))
 
   return authnResponse({
     addr: address,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -17,3 +17,4 @@ export const FLOW_EVENT_TYPES = {
 
 export const LABEL_MISSING_ERROR = "Label is required."
 export const SERVICE_ACCOUNT_LABEL = "Service Account"
+export const UNTITLED_APP_NAME = "Untitled"


### PR DESCRIPTION
The app title and icon can only be accessed on authn. This saves the app info to localstorage on sign in so it can be accessed in the authz screen.

Related conversation: https://github.com/onflow/fcl-dev-wallet/pull/37#discussion_r673140121