### PR TITLE
Updates `docker run` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ docker-compose up -d
 ```
 ## Startup Options
 
-The following startup options can be configured (defaults shown). If you're using DockerCompose, these configuration values are defined in [`docker-compose.yml`](docker-compose.yml).
+The following startup options can be configured (defaults shown). If you're using Docker Compose, these configuration values are defined in [`docker-compose.yml`](docker-compose.yml).
 
 ```bash
 docker run -it \


### PR DESCRIPTION
Fixes: #58 
- Removes whitespace form the `docker run` command in the readmen that was causing the command to fail.
- Puts command arguments and image name in the correct order for `docker run`
