### PR TITLE
Update copy on accounts list and user signature page

### DIFF
--- a/components/AccountsList.tsx
+++ b/components/AccountsList.tsx
@@ -44,7 +44,7 @@ export default function AccountsList({
     <div>
       <Box mb={4}>
         <ConnectedAppHeader
-          description="Create an account below, or select an existing account, to log in as that account."
+          description="Select an existing account to log in or create a new account."
           flowAccountAddress={flowAccountAddress}
           avatarUrl={avatarUrl}
         />

--- a/pages/fcl/user-sig.tsx
+++ b/pages/fcl/user-sig.tsx
@@ -100,9 +100,9 @@ export default function UserSign() {
     >
       <Themed.h1 sx={{textAlign: "center", mb: 0}}>Sign Message</Themed.h1>
       <Themed.p sx={{textAlign: "center", mb: 4}}>
-        Please prove you have access to this wallet.
+        Please prove that you have access to this wallet.
         <br />
-        This won’t cost you any Flow.
+        This won’t cost you any FLOW.
       </Themed.p>
       <Box mb={20}>
         <AuthzDetailsTable>


### PR DESCRIPTION
> Create an account below, or select an existing account, to log in as that account.

This felt a tad verbose to me, so proposing this change.

Also including a small copy change on the user signature page -- Flow the currency is typically written as "FLOW"