### PR TITLE
Add Authentication Refresh Service

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,6 @@
+# FCL Dev Wallet Base URL
+BASE_URL=http://localhost:8701
+
 # The FCL Dev Wallet needs to know how to talk to the emulator.
 # Because the FCL Dev Wallet is Javascript and uses FCL we talk to the emulator
 # via the emulators grpc-http proxy

--- a/next.config.js
+++ b/next.config.js
@@ -1,4 +1,25 @@
 module.exports = {
+  async headers() {
+    return [
+      {
+        // matching all API routes
+        source: "/api/:path*",
+        headers: [
+          {key: "Access-Control-Allow-Credentials", value: "true"},
+          {key: "Access-Control-Allow-Origin", value: "*"},
+          {
+            key: "Access-Control-Allow-Methods",
+            value: "GET,OPTIONS,PATCH,DELETE,POST,PUT",
+          },
+          {
+            key: "Access-Control-Allow-Headers",
+            value:
+              "X-CSRF-Token, X-Requested-With, Accept, Accept-Version, Content-Length, Content-MD5, Content-Type, Date, X-Api-Version",
+          },
+        ],
+      },
+    ]
+  },
   webpack: (config, _options) => {
     config.module.rules.push({
       test: /\.cdc/,
@@ -15,6 +36,7 @@ module.exports = {
   },
   publicRuntimeConfig: {
     flowAccountAddress: process.env.FLOW_ACCOUNT_ADDRESS,
+    baseUrl: process.env.BASE_URL,
     avatarUrl: process.env.FLOW_AVATAR_URL,
     contractFungibleToken: process.env.CONTRACT_FUNGIBLE_TOKEN,
     contractFlowToken: process.env.CONTRACT_FLOW_TOKEN,

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@onflow/util-encode-key": "^0.0.2",
         "@theme-ui/color": "^0.10.0",
         "@theme-ui/match-media": "^0.10.1",
+        "cors": "^2.8.5",
         "elliptic": "^6.5.4",
         "formik": "^2.2.9",
         "monaco-editor": "^0.27.0",
@@ -31,6 +32,7 @@
       },
       "devDependencies": {
         "@theme-ui/css": "^0.10.1",
+        "@types/cors": "^2.8.12",
         "@types/elliptic": "^6.4.12",
         "@types/node": "^15.12.5",
         "@types/react": "^17.0.11",
@@ -1495,6 +1497,12 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cors": {
+      "version": "2.8.12",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.12.tgz",
+      "integrity": "sha512-vt+kDhq/M2ayberEtJcIN/hxXy1Pk+59g2FV/ZQceeaTyCtCucjL2Q7FXlFjtWn4n15KCr1NE2lNNFhp0lEThw==",
+      "dev": true
+    },
     "node_modules/@types/elliptic": {
       "version": "6.4.13",
       "resolved": "https://registry.npmjs.org/@types/elliptic/-/elliptic-6.4.13.tgz",
@@ -2743,6 +2751,18 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/cosmiconfig": {
       "version": "6.0.0",
@@ -8212,6 +8232,14 @@
         "spdx-expression-parse": "^3.0.0"
       }
     },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/verror": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
@@ -9569,6 +9597,12 @@
         "@types/node": "*"
       }
     },
+    "@types/cors": {
+      "version": "2.8.12",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.12.tgz",
+      "integrity": "sha512-vt+kDhq/M2ayberEtJcIN/hxXy1Pk+59g2FV/ZQceeaTyCtCucjL2Q7FXlFjtWn4n15KCr1NE2lNNFhp0lEThw==",
+      "dev": true
+    },
     "@types/elliptic": {
       "version": "6.4.13",
       "resolved": "https://registry.npmjs.org/@types/elliptic/-/elliptic-6.4.13.tgz",
@@ -10515,6 +10549,15 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
+    },
+    "cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "requires": {
+        "object-assign": "^4",
+        "vary": "^1"
+      }
     },
     "cosmiconfig": {
       "version": "6.0.0",
@@ -14649,6 +14692,11 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
+    },
+    "vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
     },
     "verror": {
       "version": "1.10.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@onflow/util-encode-key": "^0.0.2",
     "@theme-ui/color": "^0.10.0",
     "@theme-ui/match-media": "^0.10.1",
+    "cors": "^2.8.5",
     "elliptic": "^6.5.4",
     "formik": "^2.2.9",
     "monaco-editor": "^0.27.0",
@@ -36,6 +37,7 @@
   },
   "devDependencies": {
     "@theme-ui/css": "^0.10.1",
+    "@types/cors": "^2.8.12",
     "@types/elliptic": "^6.4.12",
     "@types/node": "^15.12.5",
     "@types/react": "^17.0.11",

--- a/pages/api/refresh.ts
+++ b/pages/api/refresh.ts
@@ -1,0 +1,133 @@
+import {NextApiRequest, NextApiResponse} from "next"
+import getConfig from "next/config"
+
+type CompositeSignature = {
+  f_type: string
+  f_vsn: string
+  addr: string
+  keyId: number
+  signature: string
+}
+
+type AuthResponseService = {
+  f_type: string
+  f_vsn: string
+  type: string
+  uid: string
+  endpoint?: string
+  id?: string
+  method?: string
+  data?: Record<
+    string,
+    string | boolean | number | null | Array<CompositeSignature> | unknown
+  >
+  identity?: {
+    address: string
+    keyId?: number
+  }
+  provider?: {
+    address: string | null
+    name: string
+    icon: string | null
+    description: string
+  }
+  params?: Record<string, string>
+}
+
+const {publicRuntimeConfig} = getConfig()
+const address = "0xf8d6e0586b0a20c7"
+const keyId = 0
+
+const services: AuthResponseService[] = [
+  {
+    f_type: "Service",
+    f_vsn: "1.0.0",
+    type: "authn",
+    uid: "fcl-dev-wallet#authn",
+    endpoint: `${publicRuntimeConfig.baseUrl}/fcl/authn`,
+    id: address,
+    identity: {
+      address: address,
+    },
+    provider: {
+      address: null,
+      name: "FCL Dev Wallet",
+      icon: null,
+      description: "For Local Development Only",
+    },
+  },
+  {
+    f_type: "Service",
+    f_vsn: "1.0.0",
+    type: "authz",
+    uid: "fcl-dev-wallet#authz",
+    endpoint: `${publicRuntimeConfig.baseUrl}/fcl/authz`,
+    method: "IFRAME/RPC",
+    identity: {
+      address: address,
+      keyId: Number(keyId),
+    },
+  },
+  {
+    f_type: "Service",
+    f_vsn: "1.0.0",
+    type: "user-signature",
+    uid: "fcl-dev-wallet#user-sig",
+    endpoint: `${publicRuntimeConfig.baseUrl}/fcl/user-sig`,
+    method: "IFRAME/RPC",
+    id: address,
+    data: {addr: address, keyId: Number(keyId)},
+    params: {},
+  },
+  // Authentication Proof Service
+  {
+    f_type: "Service",
+    f_vsn: "1.0.0",
+    type: "account-proof",
+    method: "DATA",
+    uid: "fcl-dev-wallet#account-proof",
+    data: {
+      f_type: "account-proof",
+      f_vsn: "1.0.0",
+      address: address,
+      timestamp: Date.now(),
+      appDomainTag: "",
+      signatures: null,
+    },
+  },
+  // Authentication Refresh Service
+  {
+    f_type: "Service",
+    f_vsn: "1.0.0",
+    type: "authn-refresh",
+    uid: "fcl-dev-wallet#authn-refresh",
+    endpoint: `${publicRuntimeConfig.baseUrl}/api/refresh`,
+    method: "HTTP/POST",
+    id: address,
+    data: {
+      f_type: "authn-refresh",
+      f_vsn: "1.0.0",
+      address: address,
+      keyId: Number(keyId),
+    },
+    params: {
+      sessionId: "C7OXWaVpU-efRymW7a5d",
+    },
+  },
+]
+
+const response = {
+  f_type: "PollingResponse",
+  f_vsn: "1.0.0",
+  status: "APPROVED",
+  data: {
+    f_type: "AuthnResponse",
+    f_vsn: "1.0.0",
+    addr: address,
+    services: services,
+  },
+}
+
+export default async (req: NextApiRequest, res: NextApiResponse) => {
+  res.status(200).json(response)
+}

--- a/src/accountAuth.ts
+++ b/src/accountAuth.ts
@@ -140,6 +140,25 @@ export async function chooseAccount(
         signatures: [compSig] ?? null,
       },
     },
+    // Authentication Refresh Service
+    {
+      f_type: "Service",
+      f_vsn: "1.0.0",
+      type: "authn-refresh",
+      uid: "fcl-dev-wallet#authn-refresh",
+      endpoint: `${location.origin}/api/refresh`,
+      method: "HTTP/POST",
+      id: address,
+      data: {
+        f_type: "authn-refresh",
+        f_vsn: "1.0.0",
+        address: address,
+        keyId: Number(keyId),
+      },
+      params: {
+        sessionId: "C7OXWaVpU-efRymW7a5d",
+      },
+    },
   ]
 
   if (!!scopes.size) {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -15,6 +15,7 @@ export const paths = {
   apiSign: "/api/sign",
   userSig: "/api/user-sig",
   proveAuthn: "/api/prove-authn",
+  authnRefresh: "/api/refresh",
 }
 
 export const FLOW_EVENT_TYPES = {

--- a/src/harness/config.js
+++ b/src/harness/config.js
@@ -5,7 +5,6 @@ const USE_LOCAL = true
 // prettier-ignore
 fcl.config()
   .put("app.detail.title", "Test Harness")
-  // .put("app.detail.icon", "https://i.imgur.com/r23Zhvu.png")
   .put("app.detail.icon", "https://placekitten.com/g/200/200")
   .put("service.OpenID.scopes", "email")
 
@@ -14,7 +13,7 @@ if (USE_LOCAL) {
   fcl.config()
     .put("env", "local")
     .put("accessNode.api", "http://localhost:8080")
-    .put("discovery.wallet", "http://localhost:3000/fcl/authn")
+    .put("discovery.wallet", "http://localhost:8701/fcl/authn")
 } else {
   // prettier-ignore
   fcl.config()


### PR DESCRIPTION
### Add Authentication Refresh Service

FCL added support for a wallet provider [authentication refresh service](https://github.com/onflow/fcl-js/blob/master/packages/fcl/src/wallet-provider-spec/draft-v3.md#authentication-refresh-service). If provided, the app can check and/or refresh the wallet's user session and update `currentUser` before attempting to authorize, sign, or other service. This assures the user session with the provider has not been invalidate or expired, which can lead to a tx silently failing and out of sync session between dapp and provider.

- Add `authn-refresh` to services, 
- Add wallet baseUrl endpoint `BASE_URL=http://localhost:8701`
- Add cors, and update next.config.js
- Add `refresh` api endpoint