### PR TITLE
Remove unused init imports

### DIFF
--- a/cadence/transactions/init.cdc
+++ b/cadence/transactions/init.cdc
@@ -1,6 +1,3 @@
-import FUSD from 0xFUSDADDRESS
-import FungibleToken from 0xFUNGIBLETOKENADDRESS
-
 transaction(code: String, key: String, initAccountsLabels: [String]) {
   prepare(acct: AuthAccount) {
     acct.contracts.add(name: "FCL", code: code.decodeHex(), key: key, initAccountsLabels: initAccountsLabels)


### PR DESCRIPTION
FUSD initialization was removed in 2a48b68 . These leftover imports caused an error when the FUSD contract was missing on dev.

### Tests
- successfully started wallet without a deployed FUSD contract