### PR TITLE
Add fusd/flow funding env vars to docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,11 @@ docker run -it \
     -e FLOW_ACCOUNT_PUBLIC_KEY=519e9fbf966c6589fafe60903c0da5f55c5cb50aee5d870f097b35dfb6de13c170718cd92f50811cdd9290e51c2766440b696e0423a5031ae482cca79e3c479 \       -e FLOW_INIT_ACCOUNTS=0 \
     -e FLOW_ACCOUNT_ADDRESS=0xf8d6e0586b0a20c7 \
     -e FLOW_AVATAR_URL=https://avatars.onflow.org/avatar/ \
+    -e CONTRACT_FUNGIBLE_TOKEN=0xee82856bf20e2aa6 \
+    -e CONTRACT_FLOW_TOKEN=0x0ae53cb6e3f42a79 \
+    -e CONTRACT_FUSD=0xf8d6e0586b0a20c7 \
+    -e TOKEN_AMOUNT_FLOW=100.0 \
+    -e TOKEN_AMOUNT_FUSD=100.0 \
     ghcr.io/onflow/fcl-dev-wallet:latest  
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,11 @@ services:
       - FLOW_INIT_ACCOUNTS=0
       - FLOW_ACCOUNT_ADDRESS=0xf8d6e0586b0a20c7
       - FLOW_AVATAR_URL=https://avatars.onflow.org/avatar/
+      - CONTRACT_FUNGIBLE_TOKEN=0xee82856bf20e2aa6
+      - CONTRACT_FLOW_TOKEN=0x0ae53cb6e3f42a79
+      - CONTRACT_FUSD=0xf8d6e0586b0a20c7
+      - TOKEN_AMOUNT_FLOW=100.0
+      - TOKEN_AMOUNT_FUSD=100.0
   emulator:
     image: gcr.io/flow-container-registry/emulator:0.20.2
     ports:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,12 @@
 {
   "name": "fcl-dev-wallet",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.1.0",
+      "name": "fcl-dev-wallet",
+      "version": "0.3.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@headlessui/react": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fcl-dev-wallet",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
https://github.com/onflow/fcl-dev-wallet/pull/78 added FUSD and FLOW funding to the dev-wallet. This requires some additional env variables in the docker config

### Tests
- successfully started wallet with Docker