### PR TITLE
Update fcl and modify refresh endpoint to work with any user

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,3 @@
-# FCL Dev Wallet Base URL
-BASE_URL=http://localhost:8701
-
 # The FCL Dev Wallet needs to know how to talk to the emulator.
 # Because the FCL Dev Wallet is Javascript and uses FCL we talk to the emulator
 # via the emulators grpc-http proxy
@@ -17,6 +14,8 @@ FLOW_INIT_ACCOUNTS=0
 CONTRACT_FUNGIBLE_TOKEN=0xee82856bf20e2aa6
 CONTRACT_FLOW_TOKEN=0x0ae53cb6e3f42a79
 CONTRACT_FUSD=0xf8d6e0586b0a20c7
+FLOW_AVATAR_URL=https://avatars.onflow.org/avatar/
+
+# Funding amounts on the account page
 TOKEN_AMOUNT_FLOW=100.0
 TOKEN_AMOUNT_FUSD=100.0
-FLOW_AVATAR_URL=https://avatars.onflow.org/avatar/

--- a/README.md
+++ b/README.md
@@ -117,12 +117,14 @@ To use the dev wallet, configure FCL to point to the address of a locally runnin
 
 ```javascript
 import * as fcl from "@onflow/fcl"
+import {send as grpcSend} from "@onflow/transport-grpc"
 
 fcl.config()
   // Point App at Emulator
   .put("accessNode.api", "http://localhost:8080") 
   // Point FCL at dev-wallet (default port)
   .put("discovery.wallet", "http://localhost:8701/fcl/authn") 
+  .put("sdk.transport", grpcSend)
 ```
 
 ### Test harness 

--- a/hooks/useConnectedAppConfig.ts
+++ b/hooks/useConnectedAppConfig.ts
@@ -1,9 +1,15 @@
-import {useEffect, useState} from "react"
 import {WalletUtils} from "@onflow/fcl"
+import {useEffect, useState} from "react"
+import {parseScopes} from "src/scopes"
 
 export type ConnectedAppConfig = {
   type: string
-  body: Record<string, unknown>
+  body: {
+    appDomainTag?: string
+    data: unknown
+    extensions: unknown[]
+    timestamp: number
+  }
   service: Record<string, unknown>
   config: {
     services: {"OpenID.scopes": string}
@@ -26,10 +32,9 @@ export default function useConnectedAppConfig() {
     WalletUtils.ready(callback)
   }, [])
 
-  const appScopes =
+  const appScopes = parseScopes(
     connectedAppConfig?.config?.services?.["OpenID.scopes"]
-      ?.trim()
-      ?.split(/\s+/) ?? []
+  )
 
   return {connectedAppConfig, appScopes}
 }

--- a/modules.d.ts
+++ b/modules.d.ts
@@ -1,5 +1,6 @@
 // Untyped dependencies
 declare module "@onflow/fcl"
+declare module "@onflow/transport-grpc"
 declare module "@onflow/util-encode-key"
 declare module "@onflow/types"
 declare module "sha3"

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,5 +1,4 @@
 /// <reference types="next" />
-/// <reference types="next/types/global" />
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited

--- a/next.config.js
+++ b/next.config.js
@@ -36,7 +36,6 @@ module.exports = {
   },
   publicRuntimeConfig: {
     flowAccountAddress: process.env.FLOW_ACCOUNT_ADDRESS,
-    baseUrl: process.env.BASE_URL,
     avatarUrl: process.env.FLOW_AVATAR_URL,
     contractFungibleToken: process.env.CONTRACT_FUNGIBLE_TOKEN,
     contractFlowToken: process.env.CONTRACT_FLOW_TOKEN,

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,13 +5,13 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "fcl-dev-wallet",
       "version": "0.3.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@headlessui/react": "^1.3.0",
         "@monaco-editor/react": "^4.2.1",
-        "@onflow/fcl": "^0.0.78-alpha.4",
+        "@onflow/fcl": "^0.0.79-alpha.2",
+        "@onflow/transport-grpc": "^0.0.1",
         "@onflow/types": "^0.0.4",
         "@onflow/util-encode-key": "^0.0.2",
         "@theme-ui/color": "^0.10.0",
@@ -1085,14 +1085,14 @@
       }
     },
     "node_modules/@onflow/fcl": {
-      "version": "0.0.78-alpha.4",
-      "resolved": "https://registry.npmjs.org/@onflow/fcl/-/fcl-0.0.78-alpha.4.tgz",
-      "integrity": "sha512-2Ajeey/nuswjOsJza2N51o4+0ZMgWGYySRZL4uceFpbaoU/LDpu9bEifolcG6YH5xgt5t8thqLJg6J0f27h/Fg==",
+      "version": "0.0.79-alpha.2",
+      "resolved": "https://registry.npmjs.org/@onflow/fcl/-/fcl-0.0.79-alpha.2.tgz",
+      "integrity": "sha512-jH/peEkm7mimreFOjTndsvLnqyy5dnsFjAtfHNi1lciUap/WIAJpn/HbnzblIyh3H6fDfTgSVTKMZUOVcpoi8A==",
       "dependencies": {
         "@onflow/interaction": "0.0.11",
         "@onflow/rlp": "0.0.3",
-        "@onflow/sdk": "0.0.55",
-        "@onflow/types": "^0.0.5",
+        "@onflow/sdk": "0.0.57-alpha.2",
+        "@onflow/types": "0.0.6",
         "@onflow/util-actor": "0.0.2",
         "@onflow/util-address": "0.0.0",
         "@onflow/util-invariant": "0.0.0",
@@ -1101,9 +1101,9 @@
       }
     },
     "node_modules/@onflow/fcl/node_modules/@onflow/types": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/@onflow/types/-/types-0.0.5.tgz",
-      "integrity": "sha512-Pgh3hz3Cr8KPpkaDd1E3FdQRASGqpfA1NK7dtgz+6xdTdESeqU2z0ksocrOdfy9ikRvKt4RyFmDuXPx2CVbjuQ=="
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@onflow/types/-/types-0.0.6.tgz",
+      "integrity": "sha512-2eBrmqiFO37EUOJvzksygP8Wu6lL/m9az36AF0qYdGQW/79KGCHBCchUsIzxyGt8UDXl/dgnIcMkiTH7tWZqXg=="
     },
     "node_modules/@onflow/interaction": {
       "version": "0.0.11",
@@ -1136,19 +1136,31 @@
       "integrity": "sha512-oAf0VEiMjX8eC6Vd66j1BdGYTHOM6UBaS/sLSScnc7bKX5gICqe2gtEsCeJVE9rUzRk3GD3JqXRnPAW6YFWd/Q=="
     },
     "node_modules/@onflow/sdk": {
-      "version": "0.0.55",
-      "resolved": "https://registry.npmjs.org/@onflow/sdk/-/sdk-0.0.55.tgz",
-      "integrity": "sha512-nyPOUxmA0sLGiCXacDOhEa3d7ss36oKQ52ziIvIFM9e1eC0nerKnTfS0B22OJOncRClGE/+OT0fSxWZhTrQRBg==",
+      "version": "0.0.57-alpha.2",
+      "resolved": "https://registry.npmjs.org/@onflow/sdk/-/sdk-0.0.57-alpha.2.tgz",
+      "integrity": "sha512-Nf6AkFje63N7sMt2j7OCndiu3A9R2K+08qebAMrBXafRrahbD7YtSsbcSAIFPCmIWqbiYjIV3mBcpDOYrVdWng==",
       "dependencies": {
-        "@improbable-eng/grpc-web": "^0.14.0",
-        "@improbable-eng/grpc-web-node-http-transport": "^0.14.0",
-        "@onflow/protobuf": "^0.1.8",
         "@onflow/rlp": "^0.0.3",
         "@onflow/util-actor": "0.0.2",
         "@onflow/util-address": "^0.0.0",
         "@onflow/util-invariant": "^0.0.0",
         "@onflow/util-template": "0.0.1",
-        "deepmerge": "^4.2.2"
+        "deepmerge": "^4.2.2",
+        "sha3": "^2.1.4"
+      }
+    },
+    "node_modules/@onflow/transport-grpc": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@onflow/transport-grpc/-/transport-grpc-0.0.1.tgz",
+      "integrity": "sha512-3TE2+whyqtSmN/WWpUs6NGoSP35Ufmf4rq35w8bkaiUk+9eRYMr63VJc8G1OFaym5zIDKtGR9F1OrgENLfrx2A==",
+      "dependencies": {
+        "@improbable-eng/grpc-web": "^0.14.0",
+        "@improbable-eng/grpc-web-node-http-transport": "^0.14.0",
+        "@onflow/protobuf": "^0.1.8",
+        "@onflow/rlp": "^0.0.3",
+        "@onflow/util-address": "^0.0.0",
+        "@onflow/util-invariant": "^0.0.0",
+        "@onflow/util-template": "0.0.1"
       }
     },
     "node_modules/@onflow/types": {
@@ -4694,9 +4706,9 @@
       }
     },
     "node_modules/google-protobuf": {
-      "version": "3.18.1",
-      "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.18.1.tgz",
-      "integrity": "sha512-cDqSamZ8rGs+pOzhIsBte7wpezUKg/sggeptDWN5odhnRY/eDLa5VWLeNeQvcfiqjS3yUwgM+6OePCJMB7aWZA=="
+      "version": "3.19.4",
+      "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.19.4.tgz",
+      "integrity": "sha512-OIPNCxsG2lkIvf+P5FNfJ/Km95CsXOBecS9ZcAU6m2Rq3svc0Apl9nB3GMDNKfQ9asNv4KjyAqGwPQFrVle3Yg=="
     },
     "node_modules/graceful-fs": {
       "version": "4.2.8",
@@ -9192,14 +9204,14 @@
       }
     },
     "@onflow/fcl": {
-      "version": "0.0.78-alpha.4",
-      "resolved": "https://registry.npmjs.org/@onflow/fcl/-/fcl-0.0.78-alpha.4.tgz",
-      "integrity": "sha512-2Ajeey/nuswjOsJza2N51o4+0ZMgWGYySRZL4uceFpbaoU/LDpu9bEifolcG6YH5xgt5t8thqLJg6J0f27h/Fg==",
+      "version": "0.0.79-alpha.2",
+      "resolved": "https://registry.npmjs.org/@onflow/fcl/-/fcl-0.0.79-alpha.2.tgz",
+      "integrity": "sha512-jH/peEkm7mimreFOjTndsvLnqyy5dnsFjAtfHNi1lciUap/WIAJpn/HbnzblIyh3H6fDfTgSVTKMZUOVcpoi8A==",
       "requires": {
         "@onflow/interaction": "0.0.11",
         "@onflow/rlp": "0.0.3",
-        "@onflow/sdk": "0.0.55",
-        "@onflow/types": "^0.0.5",
+        "@onflow/sdk": "0.0.57-alpha.2",
+        "@onflow/types": "0.0.6",
         "@onflow/util-actor": "0.0.2",
         "@onflow/util-address": "0.0.0",
         "@onflow/util-invariant": "0.0.0",
@@ -9208,9 +9220,9 @@
       },
       "dependencies": {
         "@onflow/types": {
-          "version": "0.0.5",
-          "resolved": "https://registry.npmjs.org/@onflow/types/-/types-0.0.5.tgz",
-          "integrity": "sha512-Pgh3hz3Cr8KPpkaDd1E3FdQRASGqpfA1NK7dtgz+6xdTdESeqU2z0ksocrOdfy9ikRvKt4RyFmDuXPx2CVbjuQ=="
+          "version": "0.0.6",
+          "resolved": "https://registry.npmjs.org/@onflow/types/-/types-0.0.6.tgz",
+          "integrity": "sha512-2eBrmqiFO37EUOJvzksygP8Wu6lL/m9az36AF0qYdGQW/79KGCHBCchUsIzxyGt8UDXl/dgnIcMkiTH7tWZqXg=="
         }
       }
     },
@@ -9244,19 +9256,31 @@
       "integrity": "sha512-oAf0VEiMjX8eC6Vd66j1BdGYTHOM6UBaS/sLSScnc7bKX5gICqe2gtEsCeJVE9rUzRk3GD3JqXRnPAW6YFWd/Q=="
     },
     "@onflow/sdk": {
-      "version": "0.0.55",
-      "resolved": "https://registry.npmjs.org/@onflow/sdk/-/sdk-0.0.55.tgz",
-      "integrity": "sha512-nyPOUxmA0sLGiCXacDOhEa3d7ss36oKQ52ziIvIFM9e1eC0nerKnTfS0B22OJOncRClGE/+OT0fSxWZhTrQRBg==",
+      "version": "0.0.57-alpha.2",
+      "resolved": "https://registry.npmjs.org/@onflow/sdk/-/sdk-0.0.57-alpha.2.tgz",
+      "integrity": "sha512-Nf6AkFje63N7sMt2j7OCndiu3A9R2K+08qebAMrBXafRrahbD7YtSsbcSAIFPCmIWqbiYjIV3mBcpDOYrVdWng==",
       "requires": {
-        "@improbable-eng/grpc-web": "^0.14.0",
-        "@improbable-eng/grpc-web-node-http-transport": "^0.14.0",
-        "@onflow/protobuf": "^0.1.8",
         "@onflow/rlp": "^0.0.3",
         "@onflow/util-actor": "0.0.2",
         "@onflow/util-address": "^0.0.0",
         "@onflow/util-invariant": "^0.0.0",
         "@onflow/util-template": "0.0.1",
-        "deepmerge": "^4.2.2"
+        "deepmerge": "^4.2.2",
+        "sha3": "^2.1.4"
+      }
+    },
+    "@onflow/transport-grpc": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@onflow/transport-grpc/-/transport-grpc-0.0.1.tgz",
+      "integrity": "sha512-3TE2+whyqtSmN/WWpUs6NGoSP35Ufmf4rq35w8bkaiUk+9eRYMr63VJc8G1OFaym5zIDKtGR9F1OrgENLfrx2A==",
+      "requires": {
+        "@improbable-eng/grpc-web": "^0.14.0",
+        "@improbable-eng/grpc-web-node-http-transport": "^0.14.0",
+        "@onflow/protobuf": "^0.1.8",
+        "@onflow/rlp": "^0.0.3",
+        "@onflow/util-address": "^0.0.0",
+        "@onflow/util-invariant": "^0.0.0",
+        "@onflow/util-template": "0.0.1"
       }
     },
     "@onflow/types": {
@@ -12037,9 +12061,9 @@
       }
     },
     "google-protobuf": {
-      "version": "3.18.1",
-      "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.18.1.tgz",
-      "integrity": "sha512-cDqSamZ8rGs+pOzhIsBte7wpezUKg/sggeptDWN5odhnRY/eDLa5VWLeNeQvcfiqjS3yUwgM+6OePCJMB7aWZA=="
+      "version": "3.19.4",
+      "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.19.4.tgz",
+      "integrity": "sha512-OIPNCxsG2lkIvf+P5FNfJ/Km95CsXOBecS9ZcAU6m2Rq3svc0Apl9nB3GMDNKfQ9asNv4KjyAqGwPQFrVle3Yg=="
     },
     "graceful-fs": {
       "version": "4.2.8",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   "dependencies": {
     "@headlessui/react": "^1.3.0",
     "@monaco-editor/react": "^4.2.1",
-    "@onflow/fcl": "^0.0.78-alpha.4",
+    "@onflow/fcl": "^0.0.79-alpha.2",
+    "@onflow/transport-grpc": "^0.0.1",
     "@onflow/types": "^0.0.4",
     "@onflow/util-encode-key": "^0.0.2",
     "@theme-ui/color": "^0.10.0",

--- a/pages/api/prove-authn.ts
+++ b/pages/api/prove-authn.ts
@@ -1,7 +1,7 @@
-import {NextApiRequest, NextApiResponse} from "next"
-import {sign} from "src/crypto"
-import getConfig from "next/config"
 import {WalletUtils} from "@onflow/fcl"
+import {NextApiRequest, NextApiResponse} from "next"
+import getConfig from "next/config"
+import {sign} from "src/crypto"
 
 const {serverRuntimeConfig} = getConfig()
 

--- a/pages/api/refresh.ts
+++ b/pages/api/refresh.ts
@@ -1,133 +1,46 @@
+import {WalletUtils} from "@onflow/fcl"
 import {NextApiRequest, NextApiResponse} from "next"
 import getConfig from "next/config"
+import {sign} from "src/crypto"
+import {parseScopes} from "src/scopes"
+import {buildServices} from "src/services"
 
-type CompositeSignature = {
-  f_type: string
-  f_vsn: string
-  addr: string
-  keyId: number
-  signature: string
-}
-
-type AuthResponseService = {
-  f_type: string
-  f_vsn: string
-  type: string
-  uid: string
-  endpoint?: string
-  id?: string
-  method?: string
-  data?: Record<
-    string,
-    string | boolean | number | null | Array<CompositeSignature> | unknown
-  >
-  identity?: {
-    address: string
-    keyId?: number
-  }
-  provider?: {
-    address: string | null
-    name: string
-    icon: string | null
-    description: string
-  }
-  params?: Record<string, string>
-}
-
-const {publicRuntimeConfig} = getConfig()
-const address = "0xf8d6e0586b0a20c7"
-const keyId = 0
-
-const services: AuthResponseService[] = [
-  {
-    f_type: "Service",
-    f_vsn: "1.0.0",
-    type: "authn",
-    uid: "fcl-dev-wallet#authn",
-    endpoint: `${publicRuntimeConfig.baseUrl}/fcl/authn`,
-    id: address,
-    identity: {
-      address: address,
-    },
-    provider: {
-      address: null,
-      name: "FCL Dev Wallet",
-      icon: null,
-      description: "For Local Development Only",
-    },
-  },
-  {
-    f_type: "Service",
-    f_vsn: "1.0.0",
-    type: "authz",
-    uid: "fcl-dev-wallet#authz",
-    endpoint: `${publicRuntimeConfig.baseUrl}/fcl/authz`,
-    method: "IFRAME/RPC",
-    identity: {
-      address: address,
-      keyId: Number(keyId),
-    },
-  },
-  {
-    f_type: "Service",
-    f_vsn: "1.0.0",
-    type: "user-signature",
-    uid: "fcl-dev-wallet#user-sig",
-    endpoint: `${publicRuntimeConfig.baseUrl}/fcl/user-sig`,
-    method: "IFRAME/RPC",
-    id: address,
-    data: {addr: address, keyId: Number(keyId)},
-    params: {},
-  },
-  // Authentication Proof Service
-  {
-    f_type: "Service",
-    f_vsn: "1.0.0",
-    type: "account-proof",
-    method: "DATA",
-    uid: "fcl-dev-wallet#account-proof",
-    data: {
-      f_type: "account-proof",
-      f_vsn: "1.0.0",
-      address: address,
-      timestamp: Date.now(),
-      appDomainTag: "",
-      signatures: null,
-    },
-  },
-  // Authentication Refresh Service
-  {
-    f_type: "Service",
-    f_vsn: "1.0.0",
-    type: "authn-refresh",
-    uid: "fcl-dev-wallet#authn-refresh",
-    endpoint: `${publicRuntimeConfig.baseUrl}/api/refresh`,
-    method: "HTTP/POST",
-    id: address,
-    data: {
-      f_type: "authn-refresh",
-      f_vsn: "1.0.0",
-      address: address,
-      keyId: Number(keyId),
-    },
-    params: {
-      sessionId: "C7OXWaVpU-efRymW7a5d",
-    },
-  },
-]
-
-const response = {
-  f_type: "PollingResponse",
-  f_vsn: "1.0.0",
-  status: "APPROVED",
-  data: {
-    f_type: "AuthnResponse",
-    f_vsn: "1.0.0",
-    addr: address,
-    services: services,
-  },
-}
+const {serverRuntimeConfig} = getConfig()
 
 export default async (req: NextApiRequest, res: NextApiResponse) => {
+  const {address, keyId} = req.body.service.data
+  const {timestamp, appDomainTag} = req.body
+  const scopes = new Set(parseScopes(req.body?.service?.params?.scopes))
+  const signature = sign(
+    serverRuntimeConfig.flowAccountPrivateKey,
+    WalletUtils.encodeMessageForProvableAuthnSigning(
+      address,
+      timestamp,
+      appDomainTag
+    )
+  )
+  const compSig = new WalletUtils.CompositeSignature(address, keyId, signature)
+  const services = buildServices({
+    baseUrl: req.headers.origin || "",
+    address,
+    timestamp,
+    scopes,
+    compSig,
+    appDomainTag,
+    keyId,
+  })
+
+  const response = {
+    f_type: "PollingResponse",
+    f_vsn: "1.0.0",
+    status: "APPROVED",
+    data: {
+      f_type: "AuthnResponse",
+      f_vsn: "1.0.0",
+      addr: address,
+      services,
+    },
+  }
+
   res.status(200).json(response)
 }

--- a/src/accountAuth.ts
+++ b/src/accountAuth.ts
@@ -2,62 +2,7 @@ import {WalletUtils} from "@onflow/fcl"
 import {ConnectedAppConfig} from "hooks/useConnectedAppConfig"
 import {Account} from "pages/api/accounts"
 import {paths} from "src/constants"
-
-const PROFILE_SCOPES = new Set(
-  "name family_name given_name middle_name nickname preferred_username profile picture website gender birthday zoneinfo locale updated_at"
-    .trim()
-    .split(/\s+/)
-)
-const EMAIL_SCOPES = new Set("email email_verified".trim().split(/\s+/))
-
-type CompositeSignature = {
-  f_type: string
-  f_vsn: string
-  addr: string
-  keyId: number
-  signature: string
-}
-
-type AuthResponseService = {
-  f_type: string
-  f_vsn: string
-  type: string
-  uid: string
-  endpoint?: string
-  id?: string
-  method?: string
-  data?: Record<
-    string,
-    string | boolean | number | null | Array<CompositeSignature> | unknown
-  >
-  identity?: {
-    address: string
-    keyId?: number
-  }
-  provider?: {
-    address: string | null
-    name: string
-    icon: string | null
-    description: string
-  }
-  params?: Record<string, string>
-}
-
-const intersection = (a: Set<string>, b: Set<string>) =>
-  new Set([...a].filter(x => b.has(x)))
-
-function entries<T>(arr: Array<T> = []) {
-  const arrEntries = [arr].flatMap(a => a).filter(Boolean) as Iterable<
-    readonly [PropertyKey, string]
-  >
-  return Object.fromEntries(arrEntries)
-}
-
-const entry = (
-  scopes: Set<string>,
-  key: string,
-  value: string | boolean | number
-) => scopes.has(key) && [key, value]
+import {buildServices} from "./services"
 
 export async function chooseAccount(
   account: Account,
@@ -83,137 +28,15 @@ export async function chooseAccount(
       console.error("FCL-DEV-WALLET FAILED TO SIGN", e)
     })
 
-  const services: AuthResponseService[] = [
-    {
-      f_type: "Service",
-      f_vsn: "1.0.0",
-      type: "authn",
-      uid: "fcl-dev-wallet#authn",
-      endpoint: `${location.origin}/fcl/authn`,
-      id: address,
-      identity: {
-        address: address,
-      },
-      provider: {
-        address: null,
-        name: "FCL Dev Wallet",
-        icon: null,
-        description: "For Local Development Only",
-      },
-    },
-    {
-      f_type: "Service",
-      f_vsn: "1.0.0",
-      type: "authz",
-      uid: "fcl-dev-wallet#authz",
-      endpoint: `${location.origin}/fcl/authz`,
-      method: "IFRAME/RPC",
-      identity: {
-        address: address,
-        keyId: Number(keyId),
-      },
-    },
-    {
-      f_type: "Service",
-      f_vsn: "1.0.0",
-      type: "user-signature",
-      uid: "fcl-dev-wallet#user-sig",
-      endpoint: `${location.origin}/fcl/user-sig`,
-      method: "IFRAME/RPC",
-      id: address,
-      data: {addr: address, keyId: Number(keyId)},
-      params: {},
-    },
-    // Authentication Proof Service
-    {
-      f_type: "Service",
-      f_vsn: "1.0.0",
-      type: "account-proof",
-      method: "DATA",
-      uid: "fcl-dev-wallet#account-proof",
-      data: {
-        f_type: "account-proof",
-        f_vsn: "1.0.0",
-        address: address,
-        timestamp: timestamp,
-        appDomainTag: appDomainTag,
-        signatures: [compSig] ?? null,
-      },
-    },
-    // Authentication Refresh Service
-    {
-      f_type: "Service",
-      f_vsn: "1.0.0",
-      type: "authn-refresh",
-      uid: "fcl-dev-wallet#authn-refresh",
-      endpoint: `${location.origin}/api/refresh`,
-      method: "HTTP/POST",
-      id: address,
-      data: {
-        f_type: "authn-refresh",
-        f_vsn: "1.0.0",
-        address: address,
-        keyId: Number(keyId),
-      },
-      params: {
-        sessionId: "C7OXWaVpU-efRymW7a5d",
-      },
-    },
-  ]
-
-  if (!!scopes.size) {
-    services.push({
-      f_type: "Service",
-      f_vsn: "1.0.0",
-      type: "open-id",
-      uid: "fcl-dev-wallet#open-id",
-      method: "data",
-      data: {
-        f_type: "OpenID",
-        f_vsn: "1.0.0",
-        ...entries([
-          intersection(PROFILE_SCOPES, scopes).size && [
-            "profile",
-            entries([
-              entry(scopes, "name", `name[${address}]`),
-              entry(scopes, "family_name", `family_name[${address}]`),
-              entry(scopes, "given_name", `given_name[${address}]`),
-              entry(scopes, "middle_name", `middle_name[${address}]`),
-              entry(scopes, "nickname", `nickname[${address}]`),
-              entry(
-                scopes,
-                "preferred_username",
-                `preferred_username[${address}]`
-              ),
-              entry(scopes, "profile", `https://onflow.org`),
-              entry(
-                scopes,
-                "piture",
-                `https://https://avatars.onflow.org/avatar/${address}`
-              ),
-              entry(scopes, "website", "https://onflow.org"),
-              entry(scopes, "gender", `gender[${address}]`),
-              entry(
-                scopes,
-                "birthday",
-                `0000-${new Date().getMonth() + 1}-${new Date().getDate()}`
-              ),
-              entry(scopes, "zoneinfo", `America/Vancouver`),
-              entry(scopes, "locale", `en`),
-              entry(scopes, "updated_at", Date.now()),
-            ]),
-          ],
-          intersection(EMAIL_SCOPES, scopes).size && [
-            "email",
-            entries([
-              entry(scopes, "email", `${address}@example.com`),
-              entry(scopes, "email_verified", true),
-            ]),
-          ],
-        ]),
-      },
-    })
-  }
+  const services = buildServices({
+    baseUrl: location.origin,
+    address,
+    timestamp,
+    scopes,
+    compSig,
+    appDomainTag,
+    keyId,
+  })
 
   localStorage.setItem("connectedAppConfig", JSON.stringify(connectedAppConfig))
 

--- a/src/fclConfig.ts
+++ b/src/fclConfig.ts
@@ -1,4 +1,5 @@
 import {config} from "@onflow/fcl"
+import {send as grpcSend} from "@onflow/transport-grpc"
 
 export default function fclConfig(
   flowAccessNode: string,
@@ -13,4 +14,5 @@ export default function fclConfig(
     .put("0xFUNGIBLETOKENADDRESS", contractFungibleToken)
     .put("0xFLOWTOKENADDRESS", contractFlowToken)
     .put("0xFUSDADDRESS", contractFUSD)
+    .put("sdk.transport", grpcSend)
 }

--- a/src/harness/config.js
+++ b/src/harness/config.js
@@ -1,4 +1,5 @@
 import * as fcl from "@onflow/fcl"
+import {send as grpcSend} from "@onflow/transport-grpc"
 
 const USE_LOCAL = true
 
@@ -7,6 +8,8 @@ fcl.config()
   .put("app.detail.title", "Test Harness")
   .put("app.detail.icon", "https://placekitten.com/g/200/200")
   .put("service.OpenID.scopes", "email")
+  .put("fcl.appDomainTag", "harness-app")
+  .put("sdk.transport", grpcSend)
 
 if (USE_LOCAL) {
   // prettier-ignore

--- a/src/scopes.ts
+++ b/src/scopes.ts
@@ -1,0 +1,2 @@
+export const parseScopes = (scopes?: string) =>
+  scopes?.trim()?.split(/\s+/) ?? []

--- a/src/services.ts
+++ b/src/services.ts
@@ -1,0 +1,208 @@
+const PROFILE_SCOPES = new Set(
+  "name family_name given_name middle_name nickname preferred_username profile picture website gender birthday zoneinfo locale updated_at"
+    .trim()
+    .split(/\s+/)
+)
+const EMAIL_SCOPES = new Set("email email_verified".trim().split(/\s+/))
+
+type CompositeSignature = {
+  f_type: string
+  f_vsn: string
+  addr: string
+  keyId: number
+  signature: string
+}
+
+type AuthResponseService = {
+  f_type: string
+  f_vsn: string
+  type: string
+  uid: string
+  endpoint?: string
+  id?: string
+  method?: string
+  data?: Record<
+    string,
+    string | boolean | number | null | Array<CompositeSignature> | unknown
+  >
+  identity?: {
+    address: string
+    keyId?: number
+  }
+  provider?: {
+    address: string | null
+    name: string
+    icon: string | null
+    description: string
+  }
+  params?: Record<string, string>
+}
+
+const intersection = (a: Set<string>, b: Set<string>) =>
+  new Set([...a].filter(x => b.has(x)))
+
+function entries<T>(arr: Array<T> = []) {
+  const arrEntries = [arr].flatMap(a => a).filter(Boolean) as Iterable<
+    readonly [PropertyKey, string]
+  >
+  return Object.fromEntries(arrEntries)
+}
+
+const entry = (
+  scopes: Set<string>,
+  key: string,
+  value: string | boolean | number
+) => scopes.has(key) && [key, value]
+
+export const buildServices = ({
+  baseUrl,
+  address,
+  timestamp,
+  scopes,
+  compSig,
+  appDomainTag,
+  keyId,
+}: {
+  baseUrl: string
+  address: string
+  timestamp: number
+  scopes: Set<string>
+  compSig: string
+  appDomainTag?: string
+  keyId?: number
+}) => {
+  const services: AuthResponseService[] = [
+    {
+      f_type: "Service",
+      f_vsn: "1.0.0",
+      type: "authn",
+      uid: "fcl-dev-wallet#authn",
+      endpoint: `${baseUrl}/fcl/authn`,
+      id: address,
+      identity: {
+        address: address,
+      },
+      provider: {
+        address: null,
+        name: "FCL Dev Wallet",
+        icon: null,
+        description: "For Local Development Only",
+      },
+    },
+    {
+      f_type: "Service",
+      f_vsn: "1.0.0",
+      type: "authz",
+      uid: "fcl-dev-wallet#authz",
+      endpoint: `${baseUrl}/fcl/authz`,
+      method: "IFRAME/RPC",
+      identity: {
+        address: address,
+        keyId: Number(keyId),
+      },
+    },
+    {
+      f_type: "Service",
+      f_vsn: "1.0.0",
+      type: "user-signature",
+      uid: "fcl-dev-wallet#user-sig",
+      endpoint: `${baseUrl}/fcl/user-sig`,
+      method: "IFRAME/RPC",
+      id: address,
+      data: {addr: address, keyId: Number(keyId)},
+      params: {},
+    },
+    // Authentication Proof Service
+    {
+      f_type: "Service",
+      f_vsn: "1.0.0",
+      type: "account-proof",
+      method: "DATA",
+      uid: "fcl-dev-wallet#account-proof",
+      data: {
+        f_type: "account-proof",
+        f_vsn: "1.0.0",
+        address: address,
+        timestamp: timestamp,
+        appDomainTag: appDomainTag,
+        signatures: [compSig] ?? null,
+      },
+    },
+    // Authentication Refresh Service
+    {
+      f_type: "Service",
+      f_vsn: "1.0.0",
+      type: "authn-refresh",
+      uid: "fcl-dev-wallet#authn-refresh",
+      endpoint: `${baseUrl}/api/refresh`,
+      method: "HTTP/POST",
+      id: address,
+      data: {
+        f_type: "authn-refresh",
+        f_vsn: "1.0.0",
+        address: address,
+        keyId: Number(keyId),
+      },
+      params: {
+        sessionId: "C7OXWaVpU-efRymW7a5d",
+        scopes: Array.from(scopes).join(" "),
+      },
+    },
+  ]
+
+  if (!!scopes.size) {
+    services.push({
+      f_type: "Service",
+      f_vsn: "1.0.0",
+      type: "open-id",
+      uid: "fcl-dev-wallet#open-id",
+      method: "data",
+      data: {
+        f_type: "OpenID",
+        f_vsn: "1.0.0",
+        ...entries([
+          intersection(PROFILE_SCOPES, scopes).size && [
+            "profile",
+            entries([
+              entry(scopes, "name", `name[${address}]`),
+              entry(scopes, "family_name", `family_name[${address}]`),
+              entry(scopes, "given_name", `given_name[${address}]`),
+              entry(scopes, "middle_name", `middle_name[${address}]`),
+              entry(scopes, "nickname", `nickname[${address}]`),
+              entry(
+                scopes,
+                "preferred_username",
+                `preferred_username[${address}]`
+              ),
+              entry(scopes, "profile", `https://onflow.org`),
+              entry(
+                scopes,
+                "piture",
+                `https://https://avatars.onflow.org/avatar/${address}`
+              ),
+              entry(scopes, "website", "https://onflow.org"),
+              entry(scopes, "gender", `gender[${address}]`),
+              entry(
+                scopes,
+                "birthday",
+                `0000-${new Date().getMonth() + 1}-${new Date().getDate()}`
+              ),
+              entry(scopes, "zoneinfo", `America/Vancouver`),
+              entry(scopes, "locale", `en`),
+              entry(scopes, "updated_at", Date.now()),
+            ]),
+          ],
+          intersection(EMAIL_SCOPES, scopes).size && [
+            "email",
+            entries([
+              entry(scopes, "email", `${address}@example.com`),
+              entry(scopes, "email_verified", true),
+            ]),
+          ],
+        ]),
+      },
+    })
+  }
+
+  return services
+}


### PR DESCRIPTION
- updates fcl to 0.0.79-alpha.2
- adds sdk.transport config
- updates the refresh endpoint to work with any user
- fixes #91

Tested with KittyItems on dev