### PR TITLE
Fix 404 error

### DIFF
--- a/contexts/ConfigContext.tsx
+++ b/contexts/ConfigContext.tsx
@@ -38,19 +38,22 @@ async function getConfig(): Promise<RuntimeConfig> {
     return defaultConfig
   }
 
-  const result = await fetch("http://localhost:8701/api/")
-    .then(res => res.json())
-    .catch(e => {
-      console.log(
-        `Warning: Failed to fetch config from API. 
-         If you see this warning during CI you can ignore it.
-         Returning default config.
-         ${e}
-          `
-      )
-      return defaultConfig
-    })
-
+  const result = {
+    flowAccountAddress: "0xf8d6e0586b0a20c7",
+    flowAccountPrivateKey:
+      "f8e188e8af0b8b414be59c4a1a15cc666c898fb34d94156e9b51e18bfde754a5",
+    flowAccountPublicKey:
+      "6e70492cb4ec2a6013e916114bc8bf6496f3335562f315e18b085c19da659bdfd88979a5904ae8bd9b4fd52a07fc759bad9551c04f289210784e7b08980516d2",
+    flowAccountKeyId: "0",
+    flowAccessNode: "http://emulator:8888",
+    baseUrl: "http://localhost:8701",
+    contractFungibleToken: "0xee82856bf20e2aa6",
+    contractFlowToken: "0x0ae53cb6e3f42a79",
+    contractFUSD: "0xf8d6e0586b0a20c7",
+    contractFCLCrypto: "0xf8d6e0586b0a20c7",
+    avatarUrl: "",
+    flowInitAccountsNo: 0,
+  }
   return result
 }
 


### PR DESCRIPTION
cc: @valdrin-t

## observed behaviour
when you docker compose up the latest fcl-dev-wallet and emulator images, if you try to login, it hangs.
When you open the console, you see a 404 to that route
![image](https://user-images.githubusercontent.com/7823843/181251377-f51a0cdf-f086-4d0d-8aa3-edf5254b394a.png)


## reproduction steps
- `npm run build && PORT=8701 npm run start` in the current repo
- go to localhost:8701
- click Login or open the chrome dev tools

## additional context

- we have tried different node and alpine base images, and this didn't fix the issue
- we have tried `npm run dev` instead of `npm run build && PORT=8701 npm run start` and it fixed the issue
- we have tried `go run cmd/main.go` and `npm run start` together, but then the ports clash
- for some reason there is a React context that tries to fetch the fcl config from a go API which uses a bundle.zip; but isn't the fcl config available in the Next.js app anyways?

## proposed fix

the fix proposed here removes the call to the `/api` route but the fcl login still fails for a different reason