### PR TITLE
Fix markdown render issues

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,10 +1,10 @@
 <br />
-<p align="center">
+<div align="center">
   <a href="">
-    <img src="./banner.svg" alt="Logo" width="600" height="auto">
+    <img src="./banner.svg" alt="Logo" width="600" height="auto"/>
   </a>
 
-  <p align="center">
+  <div align="center">
     <i>A Flow wallet for effortless development, to be used with the Flow Emulator and FCL.</i>
     <br />
     <a href="https://docs.onflow.org/fcl/"><strong>FCL docs»</strong></a>
@@ -13,8 +13,8 @@
     <a href="https://github.com/onflow/fcl-dev-wallet/issues">Report Bug</a>
     ·
     <a href="#getting-started">Getting Started</a>
-  </p>
-</p>
+  </div>
+</div>
 <br />
 <br />
 


### PR DESCRIPTION
## Description
Fixes some minor `mdx` syntax issues to allow the docsite to ingest `overview.md`

related: https://github.com/onflow/next-docs-v1/pull/491