### PR TITLE
fix accounts can't be created/updated if transaction fees are enabled in the emulator

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/onflow/fcl-dev-wallet
+module github.com/spacepluk/fcl-dev-wallet
 
 go 1.18
 

--- a/src/accounts.ts
+++ b/src/accounts.ts
@@ -98,7 +98,6 @@ export async function newAccount(
       fcl.authorizations([authorization]),
       fcl.proposer(authorization),
       fcl.payer(authorization),
-      fcl.limit(100),
     ])
     .then(fcl.decode)
 
@@ -141,7 +140,7 @@ export async function updateAccount(
       ]),
       fcl.proposer(authorization),
       fcl.payer(authorization),
-      fcl.limit(100),
+      fcl.limit(9999),
     ])
     .then(fcl.decode)
 


### PR DESCRIPTION
Solves this problem: https://github.com/onflow/fcl-dev-wallet/issues/119