### PR TITLE
Create new accounts with an initial balance of 1000 FLOW

### DIFF
--- a/cadence/transactions/newAccount.cdc
+++ b/cadence/transactions/newAccount.cdc
@@ -14,21 +14,21 @@ transaction(label: String, scopes: [String], initialBalance: UFix64) {
     let account = FCL.new(label: label, scopes: scopes, address: nil)
   
     self.tokenAdmin = signer
-		  .borrow<&FlowToken.Administrator>(from: /storage/flowTokenAdmin)
+      .borrow<&FlowToken.Administrator>(from: /storage/flowTokenAdmin)
       ?? panic("Signer is not the token admin")
 
-		self.tokenReceiver = account
-		  .getCapability(/public/flowTokenReceiver)!
-		  .borrow<&{FungibleToken.Receiver}>()
+    self.tokenReceiver = account
+      .getCapability(/public/flowTokenReceiver)!
+      .borrow<&{FungibleToken.Receiver}>()
       ?? panic("Unable to borrow receiver reference")
   }
 
   execute {
-		let minter <- self.tokenAdmin.createNewMinter(allowedAmount: initialBalance)
-		let mintedVault <- minter.mintTokens(amount: initialBalance)
+    let minter <- self.tokenAdmin.createNewMinter(allowedAmount: initialBalance)
+    let mintedVault <- minter.mintTokens(amount: initialBalance)
 
-		self.tokenReceiver.deposit(from: <- mintedVault)
+    self.tokenReceiver.deposit(from: <- mintedVault)
 
-		destroy minter
-	}
+    destroy minter
+  }
 }

--- a/cadence/transactions/newAccount.cdc
+++ b/cadence/transactions/newAccount.cdc
@@ -1,7 +1,34 @@
 import FCL from 0xSERVICE
+import FlowToken from 0xFLOWTOKENADDRESS
+import FungibleToken from 0xFUNGIBLETOKENADDRESS
 
-transaction(label: String, scopes: [String]) {
-  prepare() {
-    FCL.new(label: label, scopes: scopes, address: nil)
+/// This transaction creates a new account and funds it with
+/// an initial balance of FLOW tokens.
+///
+transaction(label: String, scopes: [String], initialBalance: UFix64) {
+
+  let tokenAdmin: &FlowToken.Administrator
+  let tokenReceiver: &{FungibleToken.Receiver}
+
+  prepare(signer: AuthAccount) {
+    let account = FCL.new(label: label, scopes: scopes, address: nil)
+  
+    self.tokenAdmin = signer
+		  .borrow<&FlowToken.Administrator>(from: /storage/flowTokenAdmin)
+      ?? panic("Signer is not the token admin")
+
+		self.tokenReceiver = account
+		  .getCapability(/public/flowTokenReceiver)!
+		  .borrow<&{FungibleToken.Receiver}>()
+      ?? panic("Unable to borrow receiver reference")
   }
+
+  execute {
+		let minter <- self.tokenAdmin.createNewMinter(allowedAmount: initialBalance)
+		let mintedVault <- minter.mintTokens(amount: initialBalance)
+
+		self.tokenReceiver.deposit(from: <- mintedVault)
+
+		destroy minter
+	}
 }

--- a/contexts/ConfigContext.tsx
+++ b/contexts/ConfigContext.tsx
@@ -15,6 +15,7 @@ interface RuntimeConfig {
   flowAccountKeyId: string
   flowAccessNode: string
   flowInitAccountsNo: number
+  flowInitAccountBalance: string
 }
 
 const defaultConfig = {
@@ -30,6 +31,7 @@ const defaultConfig = {
   flowAccountKeyId: process.env.flowAccountKeyId || "",
   flowAccessNode: process.env.flowAccessNode || "",
   flowInitAccountsNo: parseInt(process.env.flowInitAccountsNo || "0") || 0,
+  flowInitAccountBalance: process.env.flowInitAccountBalance || "1000.0",
 }
 
 export const ConfigContext = createContext<RuntimeConfig>(defaultConfig)

--- a/src/accounts.ts
+++ b/src/accounts.ts
@@ -69,11 +69,17 @@ export async function newAccount(
     flowAccountAddress: string
     flowAccountKeyId: string
     flowAccountPrivateKey: string
+    flowInitAccountBalance: string
   },
   label: string,
   scopes: [string]
 ) {
-  const {flowAccountAddress, flowAccountKeyId, flowAccountPrivateKey} = config
+  const {
+    flowAccountAddress,
+    flowAccountKeyId,
+    flowAccountPrivateKey,
+    flowInitAccountBalance,
+  } = config
 
   const authorization = await authz(
     flowAccountAddress,
@@ -84,7 +90,12 @@ export async function newAccount(
   const txId = await fcl
     .send([
       fcl.transaction(newAccountTransaction),
-      fcl.args([fcl.arg(label, t.String), fcl.arg(scopes, t.Array(t.String))]),
+      fcl.args([
+        fcl.arg(label, t.String),
+        fcl.arg(scopes, t.Array(t.String)),
+        fcl.arg(flowInitAccountBalance, t.UFix64),
+      ]),
+      fcl.authorizations([authorization]),
       fcl.proposer(authorization),
       fcl.payer(authorization),
       fcl.limit(100),


### PR DESCRIPTION
I think we can make the dev wallet easier to use for new Flow developers by pre-funding all new accounts with an initial FLOW balance. This also matches the behaviour of the testnet faucet.

Is there any reason not to do this? Would some users benefit from creating accounts with no balance, e.g. for testing purposes?
