### PR TITLE
Use default value for missing remote config

### DIFF
--- a/contexts/ConfigContext.tsx
+++ b/contexts/ConfigContext.tsx
@@ -42,7 +42,9 @@ async function getConfig(): Promise<RuntimeConfig> {
   }
 
   const result = await fetch("http://localhost:8701/api/")
-    .then(res => res.json())
+    .then(res => res.json()).then((remoteConfig)=>{
+      return Object.assign(defaultConfig, remoteConfig)
+    })
     .catch(e => {
       console.log(
         `Warning: Failed to fetch config from API. 


### PR DESCRIPTION
Closes #186 

There was an issue for creating account because of lacking `flowInitAccountBalance`