### PR TITLE
replace docs with links

### DIFF
--- a/docs/project-development-tips.md
+++ b/docs/project-development-tips.md
@@ -1,0 +1,3 @@
+# This document has been moved to a new location:
+
+https://github.com/onflow/docs/tree/main/docs/cadence/styleguide/project-development-tips.md


### PR DESCRIPTION
replaces docs content with links to their new location in https://github.com/onflow/docs
using script from https://github.com/onflow/docs/pull/46/files#diff-c664086afba767b573a654a57f324cee7c36fe1e9b7a1a02627c642577897871