### PR TITLE
fix: increase gas limits

### DIFF
--- a/src/accounts.ts
+++ b/src/accounts.ts
@@ -98,7 +98,7 @@ export async function newAccount(
       fcl.authorizations([authorization]),
       fcl.proposer(authorization),
       fcl.payer(authorization),
-      fcl.limit(1000),
+      fcl.limit(9999),
     ])
     .then(fcl.decode)
 
@@ -141,7 +141,7 @@ export async function updateAccount(
       ]),
       fcl.proposer(authorization),
       fcl.payer(authorization),
-      fcl.limit(100),
+      fcl.limit(9999),
     ])
     .then(fcl.decode)
 

--- a/src/accounts.ts
+++ b/src/accounts.ts
@@ -98,7 +98,7 @@ export async function newAccount(
       fcl.authorizations([authorization]),
       fcl.proposer(authorization),
       fcl.payer(authorization),
-      fcl.limit(100),
+      fcl.limit(1000),
     ])
     .then(fcl.decode)
 

--- a/src/init.ts
+++ b/src/init.ts
@@ -67,7 +67,7 @@ export async function initializeWallet(config: {
       fcl.proposer(authorization),
       fcl.payer(authorization),
       fcl.authorizations([authorization]),
-      fcl.limit(200),
+      fcl.limit(9999),
     ])
     .then(fcl.decode)
 


### PR DESCRIPTION
Addresses issue https://github.com/onflow/fcl-dev-wallet/issues/216 and simply increases the gas limit for this call so that it does not fail when trying to create a new account.

**Before**

![image](https://github.com/onflow/fcl-dev-wallet/assets/2107693/747bc36a-e02d-4dcf-ae58-b8e3e7b9271d)

**After**

![image](https://github.com/onflow/fcl-dev-wallet/assets/2107693/aa854477-78c4-493c-a5a5-356099abf883)
